### PR TITLE
fix(docker-compose): disable security plugins and adjust environment …

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,9 +6,10 @@ services:
     container_name: opensearch
     environment:
       - discovery.type=single-node
-      - plugins.security.disabled=true
       - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
       - bootstrap.memory_lock=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
+      - DISABLE_SECURITY_PLUGIN=true
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
OpenSearch can not start because of the wrong settings.

Error Message

```
opensearch             | Enabling OpenSearch Security Plugin
opensearch             | Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin
opensearch             | OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user.
opensearch             | Please define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string.
opensearch             | If a password is not provided, the setup will quit.
opensearch             |  For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/
opensearch             | ### OpenSearch Security Demo Installer
opensearch             | ### ** Warning: Do not use on production or public reachable systems **
opensearch             | OpenSearch install type: rpm/deb on Linux 6.12.13-orbstack-00304-gede1cf3337c4 amd64
opensearch             | OpenSearch config dir: /usr/share/opensearch/config/
opensearch             | OpenSearch config file: /usr/share/opensearch/config/opensearch.yml
opensearch             | OpenSearch bin dir: /usr/share/opensearch/bin/
opensearch             | OpenSearch plugins dir: /usr/share/opensearch/plugins/
opensearch             | OpenSearch lib dir: /usr/share/opensearch/lib/
opensearch             | Detected OpenSearch Version: 3.0.0
opensearch             | Detected OpenSearch Security Version: 3.0.0.0
opensearch             | No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.
opensearch exited with code 1
```

Fixed by assigning the environment and values.